### PR TITLE
removed tomcat ssl cert regen inithook

### DIFF
--- a/conf.d/main
+++ b/conf.d/main
@@ -2,6 +2,9 @@
 
 a2dissite 000-default
 
+# remove tomcat sslcert gen inithook (not required when Tomcat proxied by Apache)
+rm -rf /usr/lib/inithooks/firstboot.d/16tomcat-sslcert
+
 # configure tkl-webcp
 WEBAPPS=/var/lib/tomcat7/webapps/
 WEBROOT=$WEBAPPS/cp


### PR DESCRIPTION
tomcat cert gen not required when tomcat not directly web facing
